### PR TITLE
Implement CombineReducers

### DIFF
--- a/Assets/Packages/Reduxity/ReducerCombiner.cs
+++ b/Assets/Packages/Reduxity/ReducerCombiner.cs
@@ -1,0 +1,75 @@
+using System;
+using System.IO;
+using System.Collections;
+using System.Collections.Generic;
+using Redux;
+
+namespace Reduxity {
+
+    /// <summary>
+    /// Combine multiple reducers into a single reducer,
+    /// while reflecting the shape of the state.
+    /// </summary>
+    public static class ReducerCombiner<TState> where TState: new()
+    {
+
+        /// <summary>
+        /// Combine reducers
+        /// </summary>
+        /// <param name="reducers">The reducers to combine</param>
+        /// <returns>A reducer</returns>
+        public static Reducer<TState> CombineReducers(Dictionary<string, Func<object, IAction, IState>> reducers)
+        {
+
+            return (previousState, action) => {
+
+                var hasChanged = false;
+                var nextState = new TState();
+
+                foreach (var reducerPair in reducers) {
+
+                    var reducer = reducerPair.Value;
+
+                    var previousStateForKey = getPropertyByName(previousState, reducerPair.Key);
+
+                    var nextStateForKey = reducer(previousStateForKey, action);
+
+                    if (nextStateForKey == null) {
+                        var msg = getUndefinedStateErrorMessage(reducer, action);
+                        throw new System.InvalidOperationException(msg);
+                    }
+
+                    setPropertyByName(nextState, reducerPair.Key, nextStateForKey);
+
+                    hasChanged = hasChanged || !nextStateForKey.Equals(previousStateForKey);
+                }
+
+                return hasChanged ? nextState : previousState;
+            };
+        }
+
+        private static object getPropertyByName(object obj, string name)
+        {
+            var propertyInfo = obj.GetType().GetProperty(name);
+
+            return propertyInfo != null
+                ? propertyInfo.GetValue(obj, System.Reflection.BindingFlags.Default, null, null, null)
+                : null;
+        }
+
+        private static void setPropertyByName(object obj, string name, object value) {
+            var propertyInfo = obj.GetType().GetProperty(name);
+            if (propertyInfo != null) {
+                propertyInfo.SetValue(obj, value, System.Reflection.BindingFlags.Default, null, null, null);
+            }
+        }
+
+        private static string getUndefinedStateErrorMessage (object reducer, object action) {
+            var reducerName = reducer.GetType().FullName;
+            var actionName = action.GetType().FullName;
+            return 
+                "Given action " + actionName + ", reducer '" + reducerName + 
+                "' returned undefined. " + "To ignore an action, you must explicitly return the previous state.";
+        }
+    }
+}

--- a/Assets/Packages/Reduxity/ReducerCombiner.cs.meta
+++ b/Assets/Packages/Reduxity/ReducerCombiner.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: cecb636871ce84becb8dee1ee8736bf6
+timeCreated: 1486805399
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/ReduxMovementLookExample/Redux/App.cs
+++ b/Assets/Scripts/ReduxMovementLookExample/Redux/App.cs
@@ -1,6 +1,8 @@
 ﻿using Redux;
 using UnityEngine;
 using UniRx;
+using System;
+using System.Collections.Generic;
 
 namespace Reduxity.Example.PlayerMovementLook {
 	public class App {
@@ -13,17 +15,17 @@ namespace Reduxity.Example.PlayerMovementLook {
 			State initialState = new State {}.Initialize();
 
 			// generate Store
-			Store = new Store<State>(CombineReducers, initialState); 
+			Store = new Store<State>(
+				ReducerCombiner<State>.CombineReducers(
+					new Dictionary<string, Func<object, IAction, IState>> {
+						{"Character", Movement.Reducer.Reduce},
+						{"Camera", Look.Reducer.Reduce}
+
+					}
+				),
+				initialState
+			); 
 		}
 
-		// return a new state after respective reducers. note that each reducer returns
-		// a nested state, so make sure to associate state objects with the result of the
-		// relevant reducer function.
-		private State CombineReducers(State previousState, IAction action) {
-			return new State {
-				Character = Movement.Reducer.Reduce(previousState.Character, action),
-				Camera = Look.Reducer.Reduce(previousState.Camera, action)
-			};
-		}
 	}
 }

--- a/Assets/Scripts/ReduxMovementLookExample/Redux/Modules/CharacterLook.cs
+++ b/Assets/Scripts/ReduxMovementLookExample/Redux/Modules/CharacterLook.cs
@@ -20,7 +20,10 @@ namespace Reduxity.Example.PlayerMovementLook.Look {
 
     // reducers handle state changes
     public class Reducer {
-        public static CameraState Reduce(CameraState previousState, IAction action) {
+        public static CameraState Reduce(object inState, IAction action) {
+
+            CameraState previousState = inState as CameraState;
+
             // Debug.Log($"reducing with action: {action}");
             if (action is Action.Look) {
                 return Look(previousState, (Action.Look)action);

--- a/Assets/Scripts/ReduxMovementLookExample/Redux/Modules/CharacterMover.cs
+++ b/Assets/Scripts/ReduxMovementLookExample/Redux/Modules/CharacterMover.cs
@@ -25,7 +25,10 @@ namespace Reduxity.Example.PlayerMovementLook.Movement {
 
     // reducers handle state changes
     public class Reducer {
-        public static CharacterState Reduce(CharacterState previousState, IAction action) {
+        public static CharacterState Reduce(object inState, IAction action) {
+
+            CharacterState previousState = inState as CharacterState;
+
             if (action is Action.Move) {
                 return Move(previousState, (Action.Move)action);
             }

--- a/README.md
+++ b/README.md
@@ -190,21 +190,21 @@ public class App : MonoBehaviour {
 
     private void Awake () {
         // initialize store with default values
-        State initialState = new State {}.initialize();
+        State initialState = new State {}.Initialize();
 
         // generate Store
-        Store = new Store<State>(CombineReducers, initialState); 
+        Store = new Store<State>(
+            ReducerCombiner<State>.CombineReducers(
+                new Dictionary<string, Func<object, IAction, IState>> {
+                    {"Character", Movement.Reducer.Reduce},
+                    {"Camera", Look.Reducer.Reduce}
+
+                }
+            ),
+            initialState
+        ); 
     }
 
-    // return a new state after respective reducers. note that each reducer returns
-    // a nested state, so make sure to associate state objects with the result of the
-    // relevant reducer function.
-    private State CombineReducers(State previousState, IAction action) {
-        return new State {
-            Movement = CharacterMover.Reducer.Reduce(previousState, action).Movement,
-            Counter = Counter.Reducer.Reduce(previousState, action).Counter
-        };
-    }
 }
 ```
 
@@ -236,6 +236,7 @@ An example of player movement with keyboard inputs and camera looking with mouse
 * an observer dispatching two actions
 * GameObjects (i.e., Transform) in state
 * separation of responsibilities of reducers
+* Usage of `ReducerCombiner.CombineReducers` (see [Redux's `combineReducers` docs](http://redux.js.org/docs/api/combineReducers.html#)
 
 ### ZenjectPlayerMovementLook
 All of the above but using Zenject instead of static functions and `new Class()` intializers.
@@ -266,7 +267,7 @@ A port of [redux-logger](https://github.com/evgenyrodionov/redux-logger) is incl
 
 ## FAQ
 ### Should I include the entire state object in the reducer?
-While [Redux docs](http://redux.js.org/docs/faq/Reducers.html#how-do-i-share-state-between-two-reducers-do-i-have-to-use-combinereducers) suggest this is an anti-pattern, it also provides situations where this could be desired. Ultimately, it's up to you. Just make sure you must return the entire `State` object in `CombineReducers()` on `App.cs`.
+While [Redux docs](http://redux.js.org/docs/faq/Reducers.html#how-do-i-share-state-between-two-reducers-do-i-have-to-use-combinereducers) suggest this is an anti-pattern, it also provides situations where this could be desired. Ultimately, it's up to you. Using `ReducerCombiner.CombineReducers()` can help to keep your reducers cleaner.
 
 ### Why are you mutating the state?
 Because I need to figure out how to efficiently deep clone state objects before they hit the reducer. Until then, be careful that you do not mutate the whole state.


### PR DESCRIPTION
This implements an equivalent to [Redux's `combineReducers()`](http://redux.js.org/docs/api/combineReducers.html#).

It makes heavy use of Reflection to get/set the properties on the state objects without `CombineReducers()` having to know the types of the state objects beforehand. I understand this could be a performance problem.

I also had to use the `as` keyword within a reducer to cast from `object` back to the expected state type for access there. I couldn't figure out a better way to handle that situation as I needed to pass to `CombineReducers()` a `Dictionary<string, X>` where `X` represents the reducer function. Again, without knowing the type of state before hand, and the possibility of having multiple methods passed here, each accepting a different type of state object, meant I couldn't specify `X` with any stricter typing.

I'm brand new to C#, so any suggestions on improvements are welcome :)

_NOTE: The code was heavily inspired by @gblue1223's excellent [`redux-unity3d`](https://github.com/gblue1223/redux-unity3d)_